### PR TITLE
Added grey text for no parameters

### DIFF
--- a/GammaJul.ReSharper.EnhancedTooltip/Presentation/CSharpColorizer.cs
+++ b/GammaJul.ReSharper.EnhancedTooltip/Presentation/CSharpColorizer.cs
@@ -520,13 +520,18 @@ namespace GammaJul.ReSharper.EnhancedTooltip.Presentation {
 			bool isIndexer = IsIndexer(element);
 			AppendText(isIndexer ? "[" : "(", null);
 			IList<IParameter> parameters = parametersOwner.Parameters;
+			if (parameters.Count == 0) {
+				AppendText("<no parameters>", new TextStyle(FontStyle.Regular, Color.Gray));
+			}
+			else {
 			for (int i = 0; i < parameters.Count; i++) {
-				if (i > 0)
-					AppendText(", ", null);
-				int startOffset = _richText.Length;
-				AppendParameter(parameters[i], substitution);
-				if (updatePresentedInfo)
-					_presentedInfo.Parameters.Add(new TextRange(startOffset, _richText.Length));
+					if (i > 0)
+						AppendText(", ", null);
+					int startOffset = _richText.Length;
+					AppendParameter(parameters[i], substitution);
+					if (updatePresentedInfo)
+						_presentedInfo.Parameters.Add(new TextRange(startOffset, _richText.Length));
+				}
 			}
 			AppendText(isIndexer ? "]" : ")", null);
 		}


### PR DESCRIPTION
Shame it's hardcoded to grey, but there's no other highlight id to pinch, and it's a bit overkill to create another. Looks find on Dark, Light and Blue themes.
