### PR TITLE
Max width of tooltip factored for DPI

### DIFF
--- a/GammaJul.ReSharper.EnhancedTooltip/Presentation/Styling.cs
+++ b/GammaJul.ReSharper.EnhancedTooltip/Presentation/Styling.cs
@@ -15,6 +15,7 @@ using JetBrains.ReSharper.Resources.Shell;
 using JetBrains.UI.Avalon;
 using JetBrains.UI.Extensions;
 using JetBrains.Util;
+using JetBrains.Util.Interop;
 using Screen = System.Windows.Forms.Screen;
 
 namespace GammaJul.ReSharper.EnhancedTooltip.Presentation {
@@ -175,7 +176,7 @@ namespace GammaJul.ReSharper.EnhancedTooltip.Presentation {
 
 			int limitPercent = settings.GetValue((DisplaySettings s) => s.ScreenWidthLimitPercent).Clamp(10, 100);
 			Screen screen = Screen.FromHandle(hwndSource.Handle);
-			return screen.Bounds.Width * (limitPercent / 100.0);
+			return screen.Bounds.Width * (limitPercent / 100.0) / DpiUtil.DpiHorizontalFactor;
 		}
 
 		private static TextFormattingMode GetTextFormattingMode([CanBeNull] IContextBoundSettingsStore settings)


### PR DESCRIPTION
When limiting the width of the tooltip, the screen size is found in pixels, but the list box size is set in device independent units.

When run on a high dpi machine, the size of the list box is too large, so the width isn't limited correctly.

This update factors the screen size by the screen's DPI, to make the WPF element width correct.